### PR TITLE
fix for mysql 8.0 database

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,10 @@
 FROM restic/restic:0.9.6
 
-RUN apk update && apk add python3 dcron mariadb-client postgresql-client
+RUN apk update && apk add python3 \ 
+    dcron \
+    mariadb-client \
+    postgresql-client \
+    mariadb-connector-c-dev 
 
 ADD . /restic-compose-backup
 WORKDIR /restic-compose-backup

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_namespace_packages
 setup(
     name="restic-compose-backup",
     url="https://github.com/ZettaIO/restic-compose-backup",
-    version="0.6.0",
+    version="0.6.3",
     author="Einar Forselv",
     author_email="eforselv@gmail.com",
     packages=find_namespace_packages(include=['restic_compose_backup']),
     install_requires=[
-        'docker==4.1.*',
+        'docker==6.1.*',
     ],
     entry_points={'console_scripts': [
         'restic-compose-backup = restic_compose_backup.cli:main',


### PR DESCRIPTION
[the Alpine MySQL client package (assembled from MariaDB sources) is incomplete and is not compatible with a default MySQL 8.x install](https://github.com/arey/mysql-client/issues/5) : 

- Adding 'mariadb-connector-c-dev' package.
- Update docker pip package version to 6.1  as 4.1 return error  : request() got an unexpected keyword argument 'chunked'.