### PR TITLE
bump versions; add example for rclone

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   backup:
     build: ./src

--- a/extras/example-rclone-backend/backup.env
+++ b/extras/example-rclone-backend/backup.env
@@ -1,0 +1,70 @@
+
+DOCKER_HOST=unix:///var/run/docker.sock
+# DOCKER_TLS_VERIFY=1
+# DOCKER_CERT_PATH=''
+
+INCLUDE_PROJECT_NAME=false
+EXCLUDE_BIND_MOUNTS=false
+
+# storj bucket must exist
+RESTIC_REPOSITORY=rclone:uplink:mybucket
+RESTIC_PASSWORD="password"
+
+# this env var creates on-the-fly a remote named "uplink"
+RCLONE_CONFIG_UPLINK_TYPE=storj
+# access grant must have permission to use bucket
+RCLONE_CONFIG_UPLINK_ACCESS_GRANT=
+
+RESTIC_KEEP_DAILY=7
+RESTIC_KEEP_WEEKLY=4
+RESTIC_KEEP_MONTHLY=12
+RESTIC_KEEP_YEARLY=3
+
+LOG_LEVEL=info
+CRON_SCHEDULE="10 2 * * *"
+
+# EMAIL_HOST=
+# EMAIL_PORT=
+# EMAIL_HOST_USER=
+# EMAIL_HOST_PASSWORD=
+# EMAIL_SEND_TO=
+
+# DISCORD_WEBHOOK=u
+
+# Various env vars for restic : https://restic.readthedocs.io/en/stable/040_backup.html#environment-variables
+# RESTIC_REPOSITORY                   Location of repository (replaces -r)
+# RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
+# RESTIC_PASSWORD                     The actual password for the repository
+# 
+# AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
+# AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key
+# 
+# ST_AUTH                             Auth URL for keystone v1 authentication
+# ST_USER                             Username for keystone v1 authentication
+# ST_KEY                              Password for keystone v1 authentication
+# 
+# OS_AUTH_URL                         Auth URL for keystone authentication
+# OS_REGION_NAME                      Region name for keystone authentication
+# OS_USERNAME                         Username for keystone authentication
+# OS_PASSWORD                         Password for keystone authentication
+# OS_TENANT_ID                        Tenant ID for keystone v2 authentication
+# OS_TENANT_NAME                      Tenant name for keystone v2 authentication
+# 
+# OS_USER_DOMAIN_NAME                 User domain name for keystone authentication
+# OS_PROJECT_NAME                     Project name for keystone authentication
+# OS_PROJECT_DOMAIN_NAME              PRoject domain name for keystone authentication
+# 
+# OS_STORAGE_URL                      Storage URL for token authentication
+# OS_AUTH_TOKEN                       Auth token for token authentication
+# 
+# B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
+# B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2
+# 
+# AZURE_ACCOUNT_NAME                  Account name for Azure
+# AZURE_ACCOUNT_KEY                   Account key for Azure
+# 
+# GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
+# GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)
+# 
+# RCLONE_BWLIMIT                      rclone bandwidth limit
+# RCLONE_VERBOSE=1                    # 2 for -vv

--- a/extras/example-rclone-backend/compose.yaml
+++ b/extras/example-rclone-backend/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  backup:
+    build: ../../src
+    env_file:
+      - backup.env
+    labels:
+      restic-compose-backup.volumes: false
+    volumes:
+      # Map in docker socket
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Map restic cache
+      - restic_cache:/cache
+  postgres:
+    image: postgres:12
+    env_file:
+      - postgres.env
+    labels:
+      restic-compose-backup.postgres: true
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+  restic_cache:

--- a/extras/example-rclone-backend/postgres.env
+++ b/extras/example-rclone-backend/postgres.env
@@ -1,0 +1,3 @@
+POSTGRES_USER=pguser
+POSTGRES_PASSWORD=pgpassword
+POSTGRES_DB=test

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,14 +1,22 @@
-FROM restic/restic:0.9.6
+FROM rclone/rclone:1 AS rclone
 
-RUN apk update && apk add python3 \ 
-    dcron \
-    mariadb-client \
-    postgresql-client \
-    mariadb-connector-c-dev 
+FROM restic/restic:0.16.4 AS restic
+
+FROM python:3.12-alpine
+
+COPY --from=rclone /usr/local/bin/rclone /usr/local/bin/rclone
+COPY --from=restic /usr/bin/restic /usr/local/bin/restic
+
+RUN apk update \
+    && apk add \
+        dcron \
+        mariadb-client \
+        postgresql-client \
+        mariadb-connector-c-dev
 
 ADD . /restic-compose-backup
 WORKDIR /restic-compose-backup
-RUN pip3 install -U pip setuptools wheel && pip3 install -e .
+RUN pip install -U pip setuptools wheel && pip install .
 ENV XDG_CACHE_HOME=/cache
 
 ENTRYPOINT []

--- a/src/setup.py
+++ b/src/setup.py
@@ -11,7 +11,7 @@ setup(
         'restic_compose_backup.*',
     ]),
     install_requires=[
-        'docker~=6.1.3',
+        'docker~=7.1.0',
     ],
     entry_points={'console_scripts': [
         'restic-compose-backup = restic_compose_backup.cli:main',


### PR DESCRIPTION
- add rclone to image
- add example for rclone
    - example uses the storj (uplink) remote (formerly waterbear and tardigrade), and is representative of using any rclone remote type by  following [the rclone config conventions for env var transforms](https://rclone.org/docs/#environment-variables)