### PR TITLE
Fixes, Updates, Enhancements

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -5,6 +5,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['master']
+    tags: ['*']
     paths-ignore:
         - README.MD
         - LICENSE

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -49,7 +49,7 @@ jobs:
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: .
+          context: ./src
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,64 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['master']
+    paths-ignore:
+        - README.MD
+        - LICENSE
+        - docs/
+        - extras/
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Project specific
 backup.log
 
+# Environment files (potential secrets)
+*.env
+
 # IDEs
 .vscode
 .idea

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ restic-backup.env
 
 ```bash
 RESTIC_REPOSITORY=<whatever backend restic supports>
-RESTIC_PASSWORD=hopefullyasecturepw
+RESTIC_PASSWORD=hopefullyasecurepw
 # snapshot prune rules
 RESTIC_KEEP_DAILY=7
 RESTIC_KEEP_WEEKLY=4

--- a/README.md
+++ b/README.md
@@ -195,6 +195,6 @@ Don't hesitate submitting issues, opening partial or completed pull requests.
 [documentation]: https://restic-compose-backup.readthedocs.io
 
 ---
-This project is sponsored by [zetta.io](https://www.zetta.io)
+This project was previously abandoned by [zetta.io](https://www.zetta.io)
 
-[![Zetta.IO](https://raw.githubusercontent.com/ZettaIO/restic-compose-backup/master/.github/logo.png)](https://www.zetta.io)
+[![Zetta.IO](https://raw.githubusercontent.com/lawndoc/restic-compose-backup/master/.github/logo.png)](https://www.zetta.io)

--- a/README.md
+++ b/README.md
@@ -195,6 +195,6 @@ Don't hesitate submitting issues, opening partial or completed pull requests.
 [documentation]: https://restic-compose-backup.readthedocs.io
 
 ---
-This project was previously abandoned by [zetta.io](https://www.zetta.io)
+This project is sponsored by [zetta.io](https://www.zetta.io)
 
-[![Zetta.IO](https://raw.githubusercontent.com/lawndoc/restic-compose-backup/master/.github/logo.png)](https://www.zetta.io)
+[![Zetta.IO](https://raw.githubusercontent.com/ZettaIO/restic-compose-backup/master/.github/logo.png)](https://www.zetta.io)

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ services:
     env_file:
       - restic-backup.env
     volumes:
-      # We need to communicate with docker
+      # Communicate with docker to read backup tags
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      # Persistent storage of restic cache (greatly speeds up all restic operations)
+      # Persistent restic cache (greatly speeds up all restic operations)
       - cache:/cache
   web:
     image: some_image
@@ -88,7 +88,7 @@ services:
     env_file:
       mariadb-credentials.env
     volumes:
-      - mysqldata:/var/lib/mysql
+      - mariadbdata:/var/lib/mysql
   mysql:
     image: mysql:5
     labels:

--- a/restic_compose_backup.env.template
+++ b/restic_compose_backup.env.template
@@ -1,0 +1,66 @@
+# DON'T COMMIT THIS FILE IF YOU MODIFY IN DEV
+
+# DOCKER_HOST=unix://tmp/docker.sock
+# DOCKER_TLS_VERIFY=1
+# DOCKER_CERT_PATH=''
+
+SWARM_MODE=true
+INCLUDE_PROJECT_NAME=false
+EXCLUDE_BIND_MOUNTS=false
+
+RESTIC_REPOSITORY=/restic_data
+RESTIC_PASSWORD=password
+
+RESTIC_KEEP_DAILY=7
+RESTIC_KEEP_WEEKLY=4
+RESTIC_KEEP_MONTHLY=12
+RESTIC_KEEP_YEARLY=3
+
+LOG_LEVEL=info
+CRON_SCHEDULE=10 2 * * *
+
+# EMAIL_HOST=
+# EMAIL_PORT=
+# EMAIL_HOST_USER=
+# EMAIL_HOST_PASSWORD=
+# EMAIL_SEND_TO=
+
+# DISCORD_WEBHOOK=u
+
+# Various env vars for restic : https://restic.readthedocs.io/en/stable/040_backup.html#environment-variables
+# RESTIC_REPOSITORY                   Location of repository (replaces -r)
+# RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
+# RESTIC_PASSWORD                     The actual password for the repository
+# 
+# AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
+# AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key
+# 
+# ST_AUTH                             Auth URL for keystone v1 authentication
+# ST_USER                             Username for keystone v1 authentication
+# ST_KEY                              Password for keystone v1 authentication
+# 
+# OS_AUTH_URL                         Auth URL for keystone authentication
+# OS_REGION_NAME                      Region name for keystone authentication
+# OS_USERNAME                         Username for keystone authentication
+# OS_PASSWORD                         Password for keystone authentication
+# OS_TENANT_ID                        Tenant ID for keystone v2 authentication
+# OS_TENANT_NAME                      Tenant name for keystone v2 authentication
+# 
+# OS_USER_DOMAIN_NAME                 User domain name for keystone authentication
+# OS_PROJECT_NAME                     Project name for keystone authentication
+# OS_PROJECT_DOMAIN_NAME              PRoject domain name for keystone authentication
+# 
+# OS_STORAGE_URL                      Storage URL for token authentication
+# OS_AUTH_TOKEN                       Auth token for token authentication
+# 
+# B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
+# B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2
+# 
+# AZURE_ACCOUNT_NAME                  Account name for Azure
+# AZURE_ACCOUNT_KEY                   Account key for Azure
+# 
+# GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
+# GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)
+# 
+# RCLONE_BWLIMIT                      rclone bandwidth limit
+

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,13 +1,14 @@
 FROM restic/restic:0.17.3
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update && apk add \
     python3 \
     py3-pip \
     dcron \
     mariadb-client \
-    postgresql-client \
-    mariadb-connector-c-dev 
+    mariadb-connector-c-dev
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN apk update && apk add postgresql-client
 
 ADD . /restic-compose-backup
 WORKDIR /restic-compose-backup

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM restic/restic:0.9.6
+FROM restic/restic:0.17.3
 
 RUN apk update && apk add python3 \ 
     dcron \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,8 @@
 FROM restic/restic:0.17.3
 
-RUN apk update && apk add python3 \ 
+RUN apk update && apk add \
+    python3 \
+    py3-pip \
     dcron \
     mariadb-client \
     postgresql-client \
@@ -8,7 +10,8 @@ RUN apk update && apk add python3 \
 
 ADD . /restic-compose-backup
 WORKDIR /restic-compose-backup
-RUN pip3 install -U pip setuptools wheel && pip3 install -e .
+RUN pip install -U pip setuptools wheel --break-system-packages && \
+    pip install -e . --break-system-packages
 ENV XDG_CACHE_HOME=/cache
 
 ENTRYPOINT []

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,8 +7,7 @@ RUN apk update && apk add \
     mariadb-client \
     mariadb-connector-c-dev
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN apk update && apk add postgresql-client
+RUN apk add postgresql-client --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 ADD . /restic-compose-backup
 WORKDIR /restic-compose-backup

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,6 @@
 FROM restic/restic:0.17.3
 
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update && apk add \
     python3 \
     py3-pip \

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -48,6 +48,7 @@ class MariadbContainer(Container):
             f"--user={creds['username']}",
             "--all-databases",
             "--no-tablespaces",
+            "--single-transaction",
         ]
 
     def backup(self):
@@ -114,6 +115,7 @@ class MysqlContainer(Container):
             f"--user={creds['username']}",
             "--all-databases",
             "--no-tablespaces",
+            "--single-transaction",
         ]
 
     def backup(self):

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -14,10 +14,16 @@ class MariadbContainer(Container):
 
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
+        password = self.get_config_env('MARIADB_ROOT_PASSWORD')
+        if root_password is not None:
+            username = "root"
+        else:
+            username = self.get_config_env('MARIADB_USER')
+            password = self.get_config_env('MARIADB_PASSWORD')
         return {
             'host': self.hostname,
-            'username': self.get_config_env('MARIADB_USER'),
-            'password': self.get_config_env('MARIADB_PASSWORD'),
+            'username': username,
+            'password': password,
             'port': "3306",
         }
 
@@ -74,10 +80,16 @@ class MysqlContainer(Container):
 
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
+        password = self.get_config_env('MYSQL_ROOT_PASSWORD')
+        if root_password is not None:
+            username = "root"
+        else:
+            username = self.get_config_env('MYSQL_USER')
+            password = self.get_config_env('MYSQL_PASSWORD')
         return {
             'host': self.hostname,
-            'username': self.get_config_env('MYSQL_USER'),
-            'password': self.get_config_env('MYSQL_PASSWORD'),
+            'username': username,
+            'password': password,
             'port': "3306",
         }
 

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -16,8 +16,8 @@ class MariadbContainer(Container):
         """dict: get credentials for the service"""
         return {
             'host': self.hostname,
-            'username': self.get_config_env('MYSQL_USER'),
-            'password': self.get_config_env('MYSQL_PASSWORD'),
+            'username': self.get_config_env('MARIADB_USER'),
+            'password': self.get_config_env('MARIADB_PASSWORD'),
             'port': "3306",
         }
 

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -15,7 +15,7 @@ class MariadbContainer(Container):
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
         password = self.get_config_env('MARIADB_ROOT_PASSWORD')
-        if root_password is not None:
+        if password is not None:
             username = "root"
         else:
             username = self.get_config_env('MARIADB_USER')
@@ -81,7 +81,7 @@ class MysqlContainer(Container):
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
         password = self.get_config_env('MYSQL_ROOT_PASSWORD')
-        if root_password is not None:
+        if password is not None:
             username = "root"
         else:
             username = self.get_config_env('MYSQL_USER')

--- a/src/setup.py
+++ b/src/setup.py
@@ -11,7 +11,7 @@ setup(
         'restic_compose_backup.*',
     ]),
     install_requires=[
-        'docker~=6.1.3',
+        'docker~=7.1.0',
     ],
     entry_points={'console_scripts': [
         'restic-compose-backup = restic_compose_backup.cli:main',


### PR DESCRIPTION
I found this repo while looking for a simple solution for backing up the volumes in my compose stacks. You've done some great work on this so far! Some things have broken over time, so I have returned this repo to a working state and added some enhancements.

## Breaking changes
* MariaDB environment variables updated to `MARIADB_USER` and `MARIADB_PASSWORD` from `MYSQL_*` to match the supported variables for the official mariadb container image

## Fixes
* Updated pip commands in Dockerfile because current Alpine python3 version doesn't allow pip system installs
* Using Alpine edge repo to install Postgres client because current Alpine Postgres client package doesn't support Postgres 17
* Updated docker Python module because previous version now throws an error due to deprecated protocol handler when interacting with the docker socket
* Changed README compose example's mariadb volume mount point because it was a duplicate volume shared by mariadb and mysql which caused collisions
* Various typos

## Updates
* Updated restic base image version to current

## Enhancements
* Added `--single-transaction` flag to `mysqldump` to prevent inconsistent backups for live databases
* If `MYSQL_ROOT_PASSWORD` or `MARIADB_ROOT_PASSWORD` are available, use that for backup instead of the regular user account.
* Created image build and publish workflow to automatically publish the container image on ghcr.io on updates to `master` or tag push / release.
* `.env` template file changed to `.env.template` and added `.env` to `.gitignore` to prevent accidental commits

## Future Suggestions
* Migrate all CI workflows to GitHub Actions since external contributors can't access your Travis CI instance.